### PR TITLE
Fix wrong reference to Sitecore.Kernel

### DIFF
--- a/Features/ExperienceForms/code/Stockpick.Forms.Feature.ExperienceForms/Stockpick.Forms.Feature.ExperienceForms.csproj
+++ b/Features/ExperienceForms/code/Stockpick.Forms.Feature.ExperienceForms/Stockpick.Forms.Feature.ExperienceForms.csproj
@@ -82,8 +82,8 @@
       <HintPath>..\..\..\..\packages\Sitecore.ExperienceForms.Mvc.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceForms.Mvc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel">
-      <HintPath>..\..\..\..\..\..\Repos\brunel-website\packages\Sitecore.Kernel.NoReferences.8.2.170728\lib\NET452\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Features/ExperienceForms/code/Stockpick.Forms.Feature.ExperienceForms/packages.config
+++ b/Features/ExperienceForms/code/Stockpick.Forms.Feature.ExperienceForms/packages.config
@@ -20,6 +20,5 @@
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net462" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net462" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net462" />
-  <!-- we use version 8.7 because this is matching good with Sitecore9..  depends on Newtonsoft.Json 9.0.1 -->
   <package id="WindowsAzure.Storage" version="8.7.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Sitecore.Kernel was pointing to '..\..\..\..\..\..\Repos\brunel-website\packages\Sitecore.Kernel.NoReferences.8.2.170728\lib\NET452\Sitecore.Kernel.dll' causing the build error 'error CS0234: The type or namespace name 'Diagnostics' does not exist in the namespace 'Sitecore''.

Changed reference to NuGet package folder.